### PR TITLE
Suppress RNG warnings in new R version

### DIFF
--- a/tests/testthat/test_simulation.R
+++ b/tests/testthat/test_simulation.R
@@ -213,6 +213,8 @@ test_that("sparsify",{
   expect_error(sparsify(f, minObs = 5, maxObs = 2), "'minObs' must be smaller or equal to 'maxObs'.")
   
   # check functionality:
+  # suppress warnings in transition to new RNG, as proposed by CRAN maintainers
+  suppressWarnings(RNGversion("3.5.0")) 
   set.seed(2)
   s <- as.irregFunData(sparsify(f, minObs = 2, maxObs = 4))
   expect_equal(nObs(s), 2)


### PR DESCRIPTION
Following instructions from CRAN maintainers:

The check problems with current R-devel are from

     • The default method for generating from a discrete uniform
       distribution (used in sample(), for instance) has been changed.
       ...
       The previous method can be requested using RNGkind() or
       RNGversion() if necessary for reproduction of old results.

To make your package successfully pass the checks for current R-devel
and R-release you may find it most convenient to insert

  suppressWarnings(RNGversion("3.5.0"))

before calling set.seed() in your example, vignette and test code (where
the difference in RNG sample kinds matters, of course).

Note that this ensures using the (old) non-uniform "Rounding" sampler
for all 3.x versions of R, and does not add an R version dependency.
Note also that the new "Rejection" sampler which R will use from 3.6.0
onwards by default is definitely preferable over the old one, so that
the above should really only be used as a temporary measure for
reproduction of the previous behavior (and the run time tests relying on
it).